### PR TITLE
Alexander + RawRepresentable = ❤️

### DIFF
--- a/Alexander/JSON.swift
+++ b/Alexander/JSON.swift
@@ -110,3 +110,13 @@ extension JSON: CustomDebugStringConvertible {
     }
 
 }
+
+extension JSON {
+    func decode<T: RawRepresentable>(type: T.Type) -> T? {
+        return (object as? T.RawValue).flatMap(T.init)
+    }
+
+    func decodeArray<T: RawRepresentable>(type: T.Type) -> [T]? {
+        return (object as? [T.RawValue])?.lazy.map(T.init).flatMap({ $0 })
+    }
+}

--- a/Alexander/JSON.swift
+++ b/Alexander/JSON.swift
@@ -73,6 +73,10 @@ public struct JSON {
     
     
     // MARK: - Functions
+
+    public func decode<T>(transform: JSON -> T?) -> T? {
+        return transform(self)
+    }
     
     public func decodeArray<T>(transform: JSON -> T?) -> [T]? {
         return (object as? [AnyObject])?.lazy

--- a/Alexander/JSONCodable.swift
+++ b/Alexander/JSONCodable.swift
@@ -15,6 +15,10 @@ public protocol JSONDecodable {
 }
 
 public extension Alexander.JSON {
+    public func decode<T: JSONDecodable>(type: T.Type) -> T? {
+        return decode(T.decode)
+    }
+
     public func decodeArray<T: JSONDecodable>(type: T.Type) -> [T]? {
         return decodeArray(T.decode)
     }

--- a/Readme.markdown
+++ b/Readme.markdown
@@ -42,7 +42,7 @@ struct Author: JSONDecodable {
 }
 ```
 
-Now you can do `let author = JSON["author"].decode(Author)` to get a single author, or `let authors = JSON["authors"]?.decodeArray(Author)` to get an array of authors.
+Now you can do `let author = JSON["author"]?.decode(Author)` to get a single author, or `let authors = JSON["authors"]?.decodeArray(Author)` to get an array of authors.
 
 `JSON` has helpers for extracting dates, numbers, dictionaries, arrays, urls, and strings. You can also unpack nested objects like this: `let nextCursor = JSON["meta"]?["pagination"]?["next_cursor"]?.string`.
 
@@ -59,4 +59,32 @@ extension CGSize: JSONDecodable {
         return nil
     }
 }
+```
+
+### Enums / RawRepresentable
+
+You can also decode anything that conforms to the `RawRepresentable` type. For example, assume the following enum:
+
+```swift
+enum Planet: String {
+    case Mercury = "mercury"
+    case Venus = "venus"
+    case Earth = "earth"
+    case Mars = "mars"
+    case Jupiter = "jupiter"
+    case Saturn = "saturn"
+    case Uranus = "uranus"
+    case Neptune = "Neptune"
+    // case Pluto = "pluto" =(
+}
+```
+
+Because all Swift `enum` are `RawRepresentable`, you can do the following:
+
+```swift
+let planet = JSON["planet"]?.decode(Planet)
+```
+
+```swift
+let planets = JSON["planets"]?.decodeArray(Planet)
 ```

--- a/Readme.markdown
+++ b/Readme.markdown
@@ -42,7 +42,7 @@ struct Author: JSONDecodable {
 }
 ```
 
-Now you can do `let author = JSON["author"].flatMap(Author.decode)` to get a single author, or `let authors = JSON["authors"]?.decodeArray(Author.self)` to get an array of authors.
+Now you can do `let author = JSON["author"].decode(Author)` to get a single author, or `let authors = JSON["authors"]?.decodeArray(Author)` to get an array of authors.
 
 `JSON` has helpers for extracting dates, numbers, dictionaries, arrays, urls, and strings. You can also unpack nested objects like this: `let nextCursor = JSON["meta"]?["pagination"]?["next_cursor"]?.string`.
 

--- a/Readme.markdown
+++ b/Readme.markdown
@@ -79,12 +79,4 @@ enum Planet: String {
 }
 ```
 
-Because all Swift `enum` are `RawRepresentable`, you can do the following:
-
-```swift
-let planet = JSON["planet"]?.decode(Planet)
-```
-
-```swift
-let planets = JSON["planets"]?.decodeArray(Planet)
-```
+Because `Planet` is backed by a `String` raw value type, it is inheriently `RawRepresentable`. This means you can do `let planet = JSON["planet"]?.decode(Planet)` or `let planets = JSON["planets"]?.decodeArray(Planet)`.

--- a/Readme.markdown
+++ b/Readme.markdown
@@ -74,7 +74,7 @@ enum Planet: String {
     case Jupiter = "jupiter"
     case Saturn = "saturn"
     case Uranus = "uranus"
-    case Neptune = "Neptune"
+    case Neptune = "neptune"
     // case Pluto = "pluto" =(
 }
 ```


### PR DESCRIPTION
This PR adds some new functionality:
- Adds generic `decode<T>(transform: JSON -> T) -T?` function. 
  - This allows users to decode something that might not be `JSONDecodable`.
- Adds `decode<T: JSONDecodable>(type: T.Type) -> T?` function. 
  - This builds on the previous function addition to help clean up code paths such as `let author = JSON["author"]?.decode(Author)`.
- Adds `decode<T: RawRepresentable>(type: T.Type) -> T?`
  - Allows a user to decode `JSON` into a single enum instance.
- Adds `decodeArray<T: RawRepresentable>(type: T.Type) -> [T]?`
  - Works like its `JSONDecodable` sibling, allows you to decode an array of enums.
