### PR TITLE
Correct the spelling of CocoaPods in README

### DIFF
--- a/Readme.markdown
+++ b/Readme.markdown
@@ -2,7 +2,7 @@
 
 [![Build Status](https://travis-ci.org/hodinkee/alexander.svg?branch=master)](https://travis-ci.org/hodinkee/alexander)
 [![Carthage Compatible](https://img.shields.io/badge/carthage-compatible-4BC51D.svg)](https://github.com/Carthage/Carthage)
-[![Cocoapods Compatible](https://img.shields.io/cocoapods/v/Alexander.svg)](https://cocoapods.org/?q=Alexander)
+[![CocoaPods Compatible](https://img.shields.io/cocoapods/v/Alexander.svg)](https://cocoapods.org/?q=Alexander)
 
 Alexander is an extremely simple JSON helper written in Swift. It brings type safety and Foundation helpers to the cumbersome task of JSON unpacking.
 


### PR DESCRIPTION
This pull requests corrects the spelling of **CocoaPods** 🤓
https://github.com/CocoaPods/shared_resources/tree/master/media

<blockquote class="twitter-tweet" data-lang="en"><p lang="en" dir="ltr">One day I’ll make a bot that looks through the READMEs of all Pods, looks to see if it uses “Cocoapods” and PRs “CocoaPods” :D</p>&mdash; Ørta (@orta) <a href="https://twitter.com/orta/status/697374357975388160">February 10, 2016</a></blockquote>

<script async src="//platform.twitter.com/widgets.js" charset="utf-8"></script>
